### PR TITLE
Update spss.configuration.json

### DIFF
--- a/spss.configuration.json
+++ b/spss.configuration.json
@@ -1,9 +1,9 @@
 {
     "comments": {
         // symbol used for single line comment. Remove this entry if your language does not support line comments
-        "lineComment": "//",
+        // "lineComment": "//",
         // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
-        "blockComment": [ "/*", "*/" ]
+        "blockComment": [ "*", "." ]
     },
     // symbols used as brackets
     "brackets": [


### PR DESCRIPTION
SPSS syntax doesn't seem to support single line comments. The block comment works.